### PR TITLE
feat: add Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,16 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JLR1LJY89P"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-JLR1LJY89P');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
This PR integrates Google Analytics to the main layout of the project, in order to be applied to all pages available.
The configured gtag is set up to look up to the URL: [https://proyecto-ejemplo-ruby.transbankdevelopers.cl/](https://proyecto-ejemplo-ruby.transbankdevelopers.cl/).

**Is important to remember that the tag wont be fetching data until the first version of the project is deployed, since it works only in production**

## Tests
Checking on console the contents loaded on the page validates the integration of Google Analytics to the project (look for **gtag folder** in sources tab)
![Captura de pantalla 2025-05-29 a la(s) 10 54 52 a m](https://github.com/user-attachments/assets/911105ef-f37d-4ff7-a038-7359b3c17962)

**Note: at the moment of the integration of the service, the main page is shows the content of PHP demo since it is being used as base to create the Ruby demo project** 
