### PR TITLE
TBK-340 feat: add rejected inscription view for Oneclick flow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/ruby:3.4-bookworm
+
+USER root
+
+RUN apt update \
+    && apt-get install -y --no-install-recommends ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "Transbank SDK Ruby Example",
-    "image": "mcr.microsoft.com/devcontainers/ruby:1-3.4-bookworm",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
     "postCreateCommand": "bash /workspaces/${localWorkspaceFolderBasename}/.devcontainer/post-create.sh",
     "forwardPorts": [
@@ -12,6 +15,7 @@
             "onAutoForward": "notify"
         }
     },
+    "remoteUser": "vscode",
     "mounts": [
         "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
     ],
@@ -49,6 +53,7 @@
                 "extensions.ignoreRecommendations": true,
                 "remote.containers.installRecommendedExtensions": false,
                 "settingsSync.enabled": false,
+                "todo-tree.ripgrep.ripgrep": "/usr/bin/rg",
                 "files.watcherExclude": {
                     "**/vendor/**": true,
                     "**/tmp/**": true,

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,7 +5,19 @@ sed -i 's/ZSH_THEME="devcontainers"/ZSH_THEME="robbyrussell"/' "$HOME/.zshrc" ||
 
 echo "📂 current dir: $(pwd)"
 
-bundle check || bundle install
+if ! bundle check; then
+    bundle install || {
+        echo "⚠️ bundle install falló, limpiando instalación parcial de gems y reintentando..." >&2
+
+        rm -rf /usr/local/rvm/gems/default/gems/prism-*
+        rm -rf /usr/local/rvm/gems/default/cache/prism-*.gem
+        rm -rf /usr/local/rvm/gems/default/specifications/prism-*.gemspec
+
+        bundle install
+    }
+fi
+
+gem install ruby-lsp || true
 
 if [ ! -f .env ]; then
     secret="$(bin/rails secret)"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.18)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -82,9 +82,9 @@ GEM
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.24.4)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -96,9 +96,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -113,12 +113,12 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
-    fugit (1.12.1)
+    fugit (1.12.2)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
-    globalid (1.3.0)
+    globalid (1.4.0)
       activesupport (>= 6.1)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
@@ -130,11 +130,11 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.1)
+    jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.5)
-    kamal (2.11.0)
+    json (2.20.0)
+    kamal (2.12.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)
@@ -157,14 +157,14 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.0)
-    net-imap (0.5.14)
+    msgpack (1.8.3)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -179,14 +179,24 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.3)
-    parallel (1.27.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -194,11 +204,11 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -246,29 +256,29 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.10.0)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
-    rubocop (1.76.2)
+    rubocop (1.88.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.45.1, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.45.1)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
-    rubocop-performance (1.25.0)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-rails (2.32.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.35.5)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -279,15 +289,15 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
-    rubyzip (3.3.0)
+    rubyzip (3.4.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.44.0)
+    selenium-webdriver (4.45.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    solid_cable (3.0.12)
+    solid_cable (4.0.0)
       actioncable (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -303,7 +313,12 @@ GEM
       fugit (~> 1.11)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    sqlite3 (2.9.4-x86_64-linux-gnu)
+    sqlite3 (2.9.5-aarch64-linux-gnu)
+    sqlite3 (2.9.5-aarch64-linux-musl)
+    sqlite3 (2.9.5-arm-linux-gnu)
+    sqlite3 (2.9.5-arm-linux-musl)
+    sqlite3 (2.9.5-x86_64-linux-gnu)
+    sqlite3 (2.9.5-x86_64-linux-musl)
     sshkit (1.25.0)
       base64
       logger
@@ -315,7 +330,9 @@ GEM
       railties (>= 6.0.0)
     stringio (3.2.0)
     thor (1.5.0)
-    thruster (0.1.20-x86_64-linux)
+    thruster (0.1.21)
+    thruster (0.1.21-aarch64-linux)
+    thruster (0.1.21-x86_64-linux)
     timeout (0.6.1)
     transbank-sdk (5.1.0)
       json (~> 2.6)
@@ -325,9 +342,9 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (3.1.5)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
     web-console (4.3.0)
@@ -335,16 +352,22 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.2)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
   x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   bootsnap
@@ -372,4 +395,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.5.3
+   2.6.9

--- a/app/controllers/oneclick_mall_controller.rb
+++ b/app/controllers/oneclick_mall_controller.rb
@@ -3,6 +3,9 @@ class OneclickMallController < ApplicationController
 
   logger = Logger.new(STDOUT)
   ERROR_PAGE = "shared/error_page".freeze
+  PRODUCT = "Oneclick Mall".freeze
+  REJECTED_PAGE = "error/oneclick/rejected".freeze
+  RECOVER_PAGE = "error/oneclick/recover".freeze
   before_action :set_transbank_transaction
 
   def start
@@ -30,13 +33,54 @@ class OneclickMallController < ApplicationController
   def finish
     begin
       @req = params.as_json
-      @token = @req["TBK_TOKEN"]
-      @resp = @inscription.finish(@token)  
       @response_url = oneclick_mall_finish_url
+      @token = @req["TBK_TOKEN"]
+
+      if @req["TBK_ORDEN_COMPRA"].present?
+        @request_data = @req.slice("TBK_ORDEN_COMPRA", "TBK_TOKEN", "TBK_ID_SESION")
+        @navigation = {
+          "inscription-failed" => "Inscripción Fallida",
+          "data" => "Datos recibidos",
+          "request" => "Petición",
+          "response" => "Respuesta"
+        }
+        return render RECOVER_PAGE, locals: {
+          breadcrumbs: [
+            { label: "Inicio", path: root_path },
+            { label: PRODUCT, path: oneclick_mall_start_path },
+            { label: "Inscripción anulada", path: oneclick_mall_finish_path }
+          ],
+          product: PRODUCT,
+          request_data: @request_data
+        }
+      end
+
+      @resp = @inscription.finish(@token)  
       @respond_data = @resp.with_indifferent_access
-      session[:tbk_user] = @respond_data[:tbk_user]
+      response_code = @respond_data[:response_code] || @respond_data[:responseCode] || 0
+
+      if response_code.to_i != 0
+        @navigation = {
+          "inscription-failed" => "Inscripción Fallida",
+          "data" => "Datos recibidos",
+          "request" => "Petición",
+          "response" => "Respuesta"
+        }
+        return render REJECTED_PAGE, locals: {
+          breadcrumbs: [
+            { label: "Inicio", path: root_path },
+            { label: PRODUCT, path: oneclick_mall_start_path },
+            { label: "Inscripción Fallida", path: oneclick_mall_finish_path }
+          ],
+          product: PRODUCT,
+          response_data: @respond_data,
+          token: @token
+        }
+      end
+
+      session[:tbk_user] = @respond_data[:tbk_user] || @respond_data[:tbkUser]
       @username = session[:username]
-      @tbk_user = @respond_data[:tbk_user]
+      @tbk_user = session[:tbk_user]
       @child_commerce_code1 = ::Transbank::Common::IntegrationCommerceCodes::ONECLICK_MALL_CHILD1
       @child_commerce_code2 = ::Transbank::Common::IntegrationCommerceCodes::ONECLICK_MALL_CHILD2
       @request_data  = {

--- a/app/controllers/oneclick_mall_controller.rb
+++ b/app/controllers/oneclick_mall_controller.rb
@@ -4,6 +4,13 @@ class OneclickMallController < ApplicationController
   logger = Logger.new(STDOUT)
   ERROR_PAGE = "shared/error_page".freeze
   PRODUCT = "Oneclick Mall".freeze
+  INSCRIPTION_FAILED = "Inscripción Fallida".freeze
+  FAILED_NAVIGATION = {
+    "inscription-failed" => INSCRIPTION_FAILED,
+    "data" => "Datos recibidos",
+    "request" => "Petición",
+    "response" => "Respuesta"
+  }.freeze
   REJECTED_PAGE = "error/oneclick/rejected".freeze
   RECOVER_PAGE = "error/oneclick/recover".freeze
   before_action :set_transbank_transaction
@@ -38,12 +45,7 @@ class OneclickMallController < ApplicationController
 
       if @req["TBK_ORDEN_COMPRA"].present?
         @request_data = @req.slice("TBK_ORDEN_COMPRA", "TBK_TOKEN", "TBK_ID_SESION")
-        @navigation = {
-          "inscription-failed" => "Inscripción Fallida",
-          "data" => "Datos recibidos",
-          "request" => "Petición",
-          "response" => "Respuesta"
-        }
+        @navigation = FAILED_NAVIGATION
         return render RECOVER_PAGE, locals: {
           breadcrumbs: [
             { label: "Inicio", path: root_path },
@@ -60,17 +62,12 @@ class OneclickMallController < ApplicationController
       response_code = @respond_data[:response_code] || @respond_data[:responseCode] || 0
 
       if response_code.to_i != 0
-        @navigation = {
-          "inscription-failed" => "Inscripción Fallida",
-          "data" => "Datos recibidos",
-          "request" => "Petición",
-          "response" => "Respuesta"
-        }
+        @navigation = FAILED_NAVIGATION
         return render REJECTED_PAGE, locals: {
           breadcrumbs: [
             { label: "Inicio", path: root_path },
             { label: PRODUCT, path: oneclick_mall_start_path },
-            { label: "Inscripción Fallida", path: oneclick_mall_finish_path }
+            { label: INSCRIPTION_FAILED, path: oneclick_mall_finish_path }
           ],
           product: PRODUCT,
           response_data: @respond_data,

--- a/app/controllers/oneclick_mall_deferred_controller.rb
+++ b/app/controllers/oneclick_mall_deferred_controller.rb
@@ -3,6 +3,9 @@ class OneclickMallDeferredController < ApplicationController
 
   logger = Logger.new(STDOUT)
   ERROR_PAGE = "shared/error_page".freeze
+  PRODUCT = "Oneclick Mall Diferido".freeze
+  REJECTED_PAGE = "error/oneclick/rejected".freeze
+  RECOVER_PAGE = "error/oneclick/recover".freeze
   before_action :set_transbank_transaction
 
   def start
@@ -30,13 +33,54 @@ class OneclickMallDeferredController < ApplicationController
   def finish
     begin
       @req = params.as_json
-      @token = @req["TBK_TOKEN"]
-      @resp = @inscription.finish(@token)  
       @response_url = oneclick_mall_deferred_finish_url
+      @token = @req["TBK_TOKEN"]
+
+      if @req["TBK_ORDEN_COMPRA"].present?
+        @request_data = @req.slice("TBK_ORDEN_COMPRA", "TBK_TOKEN", "TBK_ID_SESION")
+        @navigation = {
+          "inscription-failed" => "Inscripción Fallida",
+          "data" => "Datos recibidos",
+          "request" => "Petición",
+          "response" => "Respuesta"
+        }
+        return render RECOVER_PAGE, locals: {
+          breadcrumbs: [
+            { label: "Inicio", path: root_path },
+            { label: PRODUCT, path: oneclick_mall_deferred_start_path },
+            { label: "Inscripción anulada", path: oneclick_mall_deferred_finish_path }
+          ],
+          product: PRODUCT,
+          request_data: @request_data
+        }
+      end
+
+      @resp = @inscription.finish(@token)  
       @respond_data = @resp.with_indifferent_access
-      session[:tbk_user] = @respond_data[:tbk_user]
+      response_code = @respond_data[:response_code] || @respond_data[:responseCode] || 0
+
+      if response_code.to_i != 0
+        @navigation = {
+          "inscription-failed" => "Inscripción Fallida",
+          "data" => "Datos recibidos",
+          "request" => "Petición",
+          "response" => "Respuesta"
+        }
+        return render REJECTED_PAGE, locals: {
+          breadcrumbs: [
+            { label: "Inicio", path: root_path },
+            { label: PRODUCT, path: oneclick_mall_deferred_start_path },
+            { label: "Inscripción Fallida", path: oneclick_mall_deferred_finish_path }
+          ],
+          product: PRODUCT,
+          response_data: @respond_data,
+          token: @token
+        }
+      end
+
+      session[:tbk_user] = @respond_data[:tbk_user] || @respond_data[:tbkUser]
       @username = session[:username]
-      @tbk_user = @respond_data[:tbk_user]
+      @tbk_user = session[:tbk_user]
       @child_commerce_code1 = ::Transbank::Common::IntegrationCommerceCodes::ONECLICK_MALL_DEFERRED_CHILD1
       @child_commerce_code2 = ::Transbank::Common::IntegrationCommerceCodes::ONECLICK_MALL_DEFERRED_CHILD2
       @request_data  = {
@@ -158,6 +202,3 @@ class OneclickMallDeferredController < ApplicationController
   end
 
 end
-
-
-

--- a/app/controllers/oneclick_mall_deferred_controller.rb
+++ b/app/controllers/oneclick_mall_deferred_controller.rb
@@ -4,6 +4,13 @@ class OneclickMallDeferredController < ApplicationController
   logger = Logger.new(STDOUT)
   ERROR_PAGE = "shared/error_page".freeze
   PRODUCT = "Oneclick Mall Diferido".freeze
+  INSCRIPTION_FAILED = "Inscripción Fallida".freeze
+  FAILED_NAVIGATION = {
+    "inscription-failed" => INSCRIPTION_FAILED,
+    "data" => "Datos recibidos",
+    "request" => "Petición",
+    "response" => "Respuesta"
+  }.freeze
   REJECTED_PAGE = "error/oneclick/rejected".freeze
   RECOVER_PAGE = "error/oneclick/recover".freeze
   before_action :set_transbank_transaction
@@ -38,12 +45,7 @@ class OneclickMallDeferredController < ApplicationController
 
       if @req["TBK_ORDEN_COMPRA"].present?
         @request_data = @req.slice("TBK_ORDEN_COMPRA", "TBK_TOKEN", "TBK_ID_SESION")
-        @navigation = {
-          "inscription-failed" => "Inscripción Fallida",
-          "data" => "Datos recibidos",
-          "request" => "Petición",
-          "response" => "Respuesta"
-        }
+        @navigation = FAILED_NAVIGATION
         return render RECOVER_PAGE, locals: {
           breadcrumbs: [
             { label: "Inicio", path: root_path },
@@ -60,17 +62,12 @@ class OneclickMallDeferredController < ApplicationController
       response_code = @respond_data[:response_code] || @respond_data[:responseCode] || 0
 
       if response_code.to_i != 0
-        @navigation = {
-          "inscription-failed" => "Inscripción Fallida",
-          "data" => "Datos recibidos",
-          "request" => "Petición",
-          "response" => "Respuesta"
-        }
+        @navigation = FAILED_NAVIGATION
         return render REJECTED_PAGE, locals: {
           breadcrumbs: [
             { label: "Inicio", path: root_path },
             { label: PRODUCT, path: oneclick_mall_deferred_start_path },
-            { label: "Inscripción Fallida", path: oneclick_mall_deferred_finish_path }
+            { label: INSCRIPTION_FAILED, path: oneclick_mall_deferred_finish_path }
           ],
           product: PRODUCT,
           response_data: @respond_data,

--- a/app/views/error/oneclick/recover.html.erb
+++ b/app/views/error/oneclick/recover.html.erb
@@ -1,0 +1,23 @@
+<%= render 'shared/breadcrumbs', breadcrumbs: breadcrumbs %>
+
+<h1 id="inscription-failed"><%= product %> - Inscripción anulada</h1>
+<p class="mb-32">
+  La inscripción ha sido anulada por el usuario. En esta instancia, la inscripción fue abandonada al seleccionar
+  la opción de "Abandonar y volver al comercio".
+</p>
+
+<h2 id="data">Datos recibidos</h2>
+<p class="mb-32">
+  Después de que el usuario anule la inscripción en el formulario de pago, recibirás un GET con la siguiente
+  información:
+</p>
+
+<pre>
+  <code class="language-json"><%= JSON.pretty_generate(request_data) %></code>
+</pre>
+
+<h2>¡Se abandonó la inscripción!</h2>
+<p class="mb-32">
+  Este mensaje indica que la inscripción ha sido cancelada por decisión del usuario. Si tienes alguna pregunta o
+  necesitas asistencia, no dudes en contactarnos.
+</p>

--- a/app/views/error/oneclick/rejected.html.erb
+++ b/app/views/error/oneclick/rejected.html.erb
@@ -1,0 +1,38 @@
+<%= render 'shared/breadcrumbs', breadcrumbs: breadcrumbs %>
+
+<h1 id="inscription-failed"><%= product %> - Inscripción Fallida</h1>
+<p class="mb-32">
+  En esta fase pueden surgir inconvenientes, ya sea con el titular de la tarjeta o a nivel bancario, lo que
+  resulta en una inscripción fallida.
+</p>
+
+<h2 id="data">Paso 1: Datos recibidos</h2>
+<p class="mb-32">
+  Después de finalizar el flujo en el formulario de inscripción, recibirás un GET con la siguiente información:
+</p>
+
+<pre>
+  <code class="language-json"><%= JSON.pretty_generate({ TBK_TOKEN: token }) %></code>
+</pre>
+
+<h2 id="request">Paso 2: Petición de autorización</h2>
+<p class="mb-32">
+  Utiliza el token recibido para finalizar la Inscripción mediante una nueva llamada a Oneclick.
+</p>
+
+<pre>
+  <code class="language-ruby">
+  @resp = @inscription.finish(@token)
+  </code>
+</pre>
+
+<h2 id="response">Paso 3: Respuesta</h2>
+<p class="mb-32">
+  Transbank responderá con la siguiente información.
+</p>
+
+<pre class="mb-32">
+  <code class="language-json"><%= JSON.pretty_generate(response_data) %></code>
+</pre>
+
+<p class="mb-32">En este caso la inscripción fue rechazada, tendrás que repetir el proceso</p>


### PR DESCRIPTION
This branch adds support for displaying Oneclick inscription rejection and cancellation flows in the Ruby example app, matching the behavior already shown in the PHP example.

## What changed

- Added dedicated Oneclick error views under app/views/error/oneclick/
- Updated OneclickMallController and OneclickMallDeferredController to:
    - detect canceled inscriptions via TBK_ORDEN_COMPRA
   - detect rejected inscriptions via response_code != 0
   - render the new Oneclick error pages
- Added Oneclick-specific navigation sections so the pages match the expected layout and sidebar behavior

<img width="1920" height="1506" alt="image" src="https://github.com/user-attachments/assets/b5c8e018-33e0-4fea-a25a-dd3c4ff120bf" />

<img width="1920" height="1202" alt="image" src="https://github.com/user-attachments/assets/5c3a77cf-b6bc-4025-9f8e-d5deb9a14f53" />

<img width="1920" height="2297" alt="image" src="https://github.com/user-attachments/assets/b94e15ae-eed3-40d5-a06b-d620761c3d35" />
